### PR TITLE
arregla bug fecha-movimientos

### DIFF
--- a/server/models/movement.js
+++ b/server/models/movement.js
@@ -74,7 +74,7 @@ const createMovement = ({
     category = '',
     description = '',
 } = {}) => {
-    date = new Date()
+    //date = new Date()
     return Movement.create({ date, amount, type, category, description });
 };
 


### PR DESCRIPTION
se arregló bug que hace que todos los movimientos se creen con la fecha de hoy. Ahora toma la fecha del formulario.