### PR TITLE
Implementa test para el refresco de la lista al crear un movimiento

### DIFF
--- a/tests/e2e/specs/expense.spec.js
+++ b/tests/e2e/specs/expense.spec.js
@@ -1,0 +1,17 @@
+describe('Egresos Test', () => {
+    // Limpio la db antes de cada test
+    beforeEach(() => {
+        cy.task('seed');
+    });
+
+    it('Deberia poder crear un nuevo egreso', () => {
+        cy.visit('/expense');
+
+        cy.get('input[name=date]').type('2021-04-26');
+        cy.get('input[name=category]').type('Bono');
+        cy.get('input[name=amount]').type('100000');
+        cy.contains('Guardar').click();
+
+        cy.get('[data-testid=movement]').should('have.length', 6);
+    });
+});

--- a/tests/e2e/specs/income.spec.js
+++ b/tests/e2e/specs/income.spec.js
@@ -24,7 +24,6 @@ describe('Ingresos Test', () => {
         cy.get('input[name=category]').type('Bono');
         cy.get('input[name=amount]').type('100000');
         cy.contains('Guardar').click();
-        cy.reload();
 
         cy.get('[data-testid=movement]').should('have.length', 5);
     });


### PR DESCRIPTION
Se quita el reload en "income.spec.js" ya que no es necesario refrescar porque la lista refleja el cambio automáticamente. 
Si bien el controlador es el mismo para los ingresos y egresos (movimientos) creí conveniente crear otro test para verificar que la lista de egresos refleje el cambio automáticamente.