### PR TITLE
Bug/arregla orden lista movimientos

### DIFF
--- a/client/js/movement-service.js
+++ b/client/js/movement-service.js
@@ -1,13 +1,13 @@
 const BASE_URL = '/api/v1';
 
 async function getLast() {
-    const resp = await fetch(`${BASE_URL}/movements`);
+    const resp = await fetch(`${BASE_URL}/movements?sort=date:DESC`);
     const { movements } = await resp.json();
     return movements;
 }
 
 async function getMovementsByType(type) {
-    const resp = await fetch(`${BASE_URL}/movements?type=` + type);
+    const resp = await fetch(`${BASE_URL}/movements?type=` + type + `&sort=date:DESC`);
     const { movements } = await resp.json();
     return movements;
 }

--- a/client/js/utils.js
+++ b/client/js/utils.js
@@ -48,5 +48,5 @@ export function formatDate(date) {
 }
 
 export function listDate(date) {
-    return new Date(date).toLocaleString();
+    return new Date(date).toLocaleString("es-419");
 }

--- a/client/views/components/movement.html
+++ b/client/views/components/movement.html
@@ -12,7 +12,7 @@
         <div class="level-item">
             <div>
                 <p class="has-text-weight-medium">{{ movement.category }}</p>
-                <p class="has-text-weight-light is-size-7">
+                <p data-testid="movement-date" class="has-text-weight-light is-size-7">
                     {{ movement.date | listDate }}
                 </p>
             </div>

--- a/server/models/movement.js
+++ b/server/models/movement.js
@@ -42,7 +42,7 @@ const Movement = db.define(
  * Obtener todos los movimientos de la base de datos.
  *
  */
-const getAllMovements = (limit, skip, type) => {
+const getAllMovements = (limit, skip, type, sort) => {
     let where = {};
 
     if (type) {
@@ -52,7 +52,17 @@ const getAllMovements = (limit, skip, type) => {
         };
     }
 
+    let sortClause = [['id']];
+    if(sort){
+        if(sort.includes(":"))
+            sortClause = [[sort.slice(0, sort.indexOf(":")) , sort.slice(sort.indexOf(":") + 1).toUpperCase()]];
+        else
+            sortClause = [[sort]];
+        
+    }
+
     return Movement.findAndCountAll({
+        order: sortClause, 
         limit: limit,
         offset: skip,
         attributes: {

--- a/server/routes/movement.js
+++ b/server/routes/movement.js
@@ -8,7 +8,7 @@ const router = express.Router();
  *
  */
 router.get('/', function (req, res) {
-    MovementModel.getAll(req.query.limit, req.skip, req.query.type)
+    MovementModel.getAll(req.query.limit, req.skip, req.query.type, req.query.sort)
         .then((results) => {
             const pageCount = Math.ceil(results.count / req.query.limit);
 

--- a/tests/e2e/specs/expense.spec.js
+++ b/tests/e2e/specs/expense.spec.js
@@ -65,4 +65,22 @@ describe('Egresos Test', () => {
         });
     });
 
+    it('Los últimos egresos deberían estar ordenados por fecha descendente', () => {
+        cy.visit('/expense');
+        var lastDate = "";
+        cy.get('[data-testid=movement-date]').each((item, index) => {
+            cy.wrap(item).invoke('text').then((text) => 
+            {
+                var dateParts = text.split('/');
+                var actDate = new Date(parseInt(dateParts[2].slice(0,4)), parseInt(dateParts[1]), parseInt(dateParts[0]));
+                if(index > 0)
+                    cy.wrap(actDate).should('be.lte', lastDate);
+                
+                lastDate = actDate;
+            });
+           
+        });
+    });
+
+
 });

--- a/tests/e2e/specs/home.spec.js
+++ b/tests/e2e/specs/home.spec.js
@@ -25,4 +25,21 @@ describe('Home Test', () => {
             .title()
             .should('eq', 'Gitapp - Ingresos')
     });
+
+    it('Los últimos movimientos deberían estar ordenados por fecha descendente', () => {
+        cy.visit('/');
+        var lastDate = "";
+        cy.get('[data-testid=movement-date]').each((item, index) => {
+            cy.wrap(item).invoke('text').then((text) => 
+            {
+                var dateParts = text.split('/');
+                var actDate = new Date(parseInt(dateParts[2].slice(0,4)), parseInt(dateParts[1]), parseInt(dateParts[0]));
+                if(index > 0)
+                    cy.wrap(actDate).should('be.lte', lastDate);
+                
+                lastDate = actDate;
+            });
+           
+        });
+    });
 });

--- a/tests/e2e/specs/income.spec.js
+++ b/tests/e2e/specs/income.spec.js
@@ -12,9 +12,9 @@ describe('Ingresos Test', () => {
             .contains('editar')
             .click();
 
-        cy.get('input[name=id]').should('have.value', '3');
-        cy.get('input[name=category]').should('have.value', 'Sueldo');
-        cy.get('input[name=amount]').should('have.value', '50000');
+        cy.get('input[name=id]').should('have.value', '14');
+        cy.get('input[name=category]').should('have.value', 'Plazo Fijo');
+        cy.get('input[name=amount]').should('have.value', '11000');
     });
 
     it('Deberia poder crear un nuevo ingreso', () => {
@@ -37,5 +37,22 @@ describe('Ingresos Test', () => {
         cy.contains('Guardar').click();
 
         cy.get('[data-testid=save-alert]').should('be.visible');
+    });
+
+    it('Los últimos ingresos deberían estar ordenados por fecha descendente', () => {
+        cy.visit('/income');
+        var lastDate = "";
+        cy.get('[data-testid=movement-date]').each((item, index) => {
+            cy.wrap(item).invoke('text').then((text) => 
+            {
+                var dateParts = text.split('/');
+                var actDate = new Date(parseInt(dateParts[2].slice(0,4)), parseInt(dateParts[1]), parseInt(dateParts[0]));
+                if(index > 0)
+                    cy.wrap(actDate).should('be.lte', lastDate);
+                
+                lastDate = actDate;
+            });
+           
+        });
     });
 });

--- a/tests/integration/index.test.js
+++ b/tests/integration/index.test.js
@@ -202,6 +202,33 @@ test('Buscar movimientos por api filtrando por tipo inexistente', async() => {
     expect(response.movements.length).toBe(0);
 });
 
+test('Buscar movimientos por api ordenando por fecha descendente', async() => {
+    const firstMovementData = {
+        date: new Date(2021, 2, 15),
+        amount: 1000.0,
+        category: 'Supermercado',
+    };
+
+    const secondMovementData = {
+        date: new Date(2021, 6, 19),
+        amount: 50000.0,
+        type: MovementType.INCOME,
+        category: 'Sueldo',
+    };
+
+    // Creamos los movimientos
+    await MovementModel.create(firstMovementData);
+    await MovementModel.create(secondMovementData);
+
+    const URL = `${baseURL}/movements?sort=date:DESC`;
+    const req = await fetch(URL);
+    const response = await req.json();
+
+    expect(response.movements.length).toBe(2);
+    expect(new Date(response.movements[0].date)).toStrictEqual(secondMovementData.date);
+});
+
+
 test('Buscar movimientos por api con más de un resultado', async() => {
     const firstMovementData = {
         date: '01/01/2021',

--- a/tests/unit/models.spec.js
+++ b/tests/unit/models.spec.js
@@ -156,6 +156,32 @@ test('Listar movimientos con limite y offset', async() => {
     expect(movements.rows[0].id).toBe(movement.id);
 });
 
+test('Listar movimientos ordenando por fecha descendente', async() => {
+    const firstMovementData = {
+        date: new Date(2021, 1, 3),
+        amount: 50000.0,
+        type: MovementType.INCOME,
+        category: 'Sueldo',
+    };
+
+    const secondMovementData = {
+        date: new Date(2021, 5, 24),
+        amount: 50000.0,
+        type: MovementType.EXPENSE,
+        category: 'Sueldo',
+    };
+
+    // Creamos los movimientos
+    await MovementModel.create(firstMovementData);
+    await MovementModel.create(secondMovementData);
+
+    let movements = await MovementModel.getAll(null, null, null, 'date:desc');
+
+    // La lista de movimientos debería empezar con los datos de secondMovementData (fecha mayor)
+    expect(movements.rows.length).toBe(2);
+    expect(movements.rows[0].date).toStrictEqual(secondMovementData.date);
+});
+
 test('Filtrar movimientos por tipo income', async() => {
     const firstMovementData = {
         date: '04/01/2021',


### PR DESCRIPTION
Resuelve bug del orden de las listas de movimientos en home, income y expense.
El modelo y la API siempre retornaba los movimientos ordenados por "id", lo más sencillo hubiese sido que directamente el modelo los devuelva ordenado por fecha descendente pero esto hacía romper otros tests, escritos previamente, que toman como que el orden es por id, por esta razón se tuvo que agregar un criterio de orden en el modelo y en la API.
Adjunto documentación de la API por si lo necesitan
[IS - Trabajo integrador - 2021  - API - V2.pdf](https://github.com/daplp84/gitapp/files/6681693/IS.-.Trabajo.integrador.-.2021.-.API.-.V2.pdf)
.