### PR TITLE
Agregar signo correspondiente a cada movimiento

### DIFF
--- a/client/views/components/movement.html
+++ b/client/views/components/movement.html
@@ -21,6 +21,11 @@
 
     <div class="level-right">
         <div class="level-item">
+            <p  data-testid="movement-amount"
+                class="{{ 'has-text-success' if movement.type == 'income' else 'has-text-danger' }} is-size-3"
+            >
+                {{ '+' if movement.type == 'income' else '-' }}
+            </p>
             <p
                 class="{{ 'has-text-success' if movement.type == 'income' else 'has-text-danger' }} is-size-3"
             >

--- a/tests/e2e/specs/expense.spec.js
+++ b/tests/e2e/specs/expense.spec.js
@@ -82,5 +82,10 @@ describe('Egresos Test', () => {
         });
     });
 
-
+    it('Deberia aparecer el signo - delante de cada egreso', () => {
+        cy.visit('/expense');
+        cy.get('[data-testid=movement-amount]').each( (item) => {
+            cy.wrap(item).invoke('text').should('contain', '-');
+        });
+    });
 });

--- a/tests/e2e/specs/home.spec.js
+++ b/tests/e2e/specs/home.spec.js
@@ -42,4 +42,17 @@ describe('Home Test', () => {
            
         });
     });
+
+    it('Deberia aparecer el signo correspondiente delante de cada movimiento', () => {
+        cy.visit('/');
+        cy.get('[data-testid=movement]').each( (item) => {
+            cy.wrap(item).get('[data-testid=movement-icon]').invoke('attr', 'src').then((src) => {
+                if(src.includes('expense')){
+                    cy.wrap(item).get('[data-testid=movement-amount]').should('contain', '-');
+                }else{
+                    cy.wrap(item).get('[data-testid=movement-amount]').should('contain', '+');
+                }
+            });
+        });
+    });
 });

--- a/tests/e2e/specs/income.spec.js
+++ b/tests/e2e/specs/income.spec.js
@@ -55,4 +55,11 @@ describe('Ingresos Test', () => {
            
         });
     });
+
+    it('Deberia aparecer el signo + delante de cada ingreso', () => {
+        cy.visit('/income');
+        cy.get('[data-testid=movement-amount]').each( (item) => {
+            cy.wrap(item).invoke('text').should('contain', '+');
+        });
+    });
 });


### PR DESCRIPTION
Se agrega el signo del monto en las tablas. Para un movimiento de tipo income, se agrega el signo (+) y para un movimiento de tipo expense, el signo (-). 
Por otro lado se testea en las tablas que el movimiento tenga el signo correspondiente. Para ello, se hizo un test e2e analizando la tabla de Ingresos, Egresos y Últimos Movimientos. 

Se adjunta el reporte de coverage: 

[coverage.txt](https://github.com/daplp84/gitapp/files/6683006/coverage.txt)
